### PR TITLE
Update WORKSPACE environment after updating Jenkins workspace

### DIFF
--- a/vars/buildWorkspace.groovy
+++ b/vars/buildWorkspace.groovy
@@ -4,8 +4,10 @@ def call(Map opts = [:], body) {
   def workspace = opts.workspace ?: '/home/jenkins/workspace'
   def jobName = env.JOB_NAME.replaceAll(/[^A-Za-z0-9]+/, '-')
   def buildNumber = env.BUILD_NUMBER
+  def dir = "${workspace}/${jobName}-${buildNumber}"
 
-  ws(dir: "${workspace}/${jobName}-${buildNumber}") {
+  ws(dir: dir) {
+    body.env.WORKSPACE = dir
     body()
   }
 }


### PR DESCRIPTION
Makes it possible to use `env.WORKSPACE` instead of calculating `pwd` for current working directory.