### PR TITLE
Make credentials non-env specific by default

### DIFF
--- a/vars/envCredentials.groovy
+++ b/vars/envCredentials.groovy
@@ -7,7 +7,9 @@ void call(String env, List creds, Map opts, Object body) {
   List credentials = []
 
   creds.eachWithIndex { cred, index ->
-    String id = "${env}_${cred.id}"
+    Boolean prependEnv = cred.prependEnv ?: false
+    String id = prependEnv ? "${env}_${cred.id}" : cred.id
+
     String var = cred.env ? cred.env : "${prefix}${cred.id}"
     credentials.add(string(credentialsId: id, variable: var))
   }


### PR DESCRIPTION
Lots of credentials like client_id and so on are non-env specific
and therefore doesnt need to be prefixed with the env name