### PR TITLE
Set Kaniko image to latest released version (0.24.0).

### DIFF
--- a/vars/defaultContainers.groovy
+++ b/vars/defaultContainers.groovy
@@ -8,7 +8,7 @@ Map call() {
     cd: cdImg,
     ace: 'evryace/ace-2-values:17',
     jenkins: 'jenkins/jnlp-slave:alpine',
-    kaniko: 'gcr.io/kaniko-project/executor:debug-v0.16.0',
+    kaniko: 'gcr.io/kaniko-project/executor:debug-v0.24.0',
   ]
 
   return containers


### PR DESCRIPTION

Due to requiring `COPY --chown` in new project - feature provided in `kaniko v0.18.0` updating to latest version of Kaniko.