### PR TITLE
Ensure chart folder is removed before new copy

### DIFF
--- a/vars/helmPullChart.groovy
+++ b/vars/helmPullChart.groovy
@@ -10,6 +10,7 @@ void call(String chart, Map opts = [:]) {
       set -u
       set -e
 
+      rm -rf chart
       mkdir chart
 
       # Set Helm Home


### PR DESCRIPTION
- Jenkins running in docker
- Bulid agens volume mount to same volume in multi stage build
- Chart folder created in first build step
- Chart folder 'mkdir chart' fails in next step:
  mkdir: can't create directory 'chart': File exists