### PR TITLE
Empty 'gitops' folder before git clone command

### DIFF
--- a/vars/acePushConfigToGit.groovy
+++ b/vars/acePushConfigToGit.groovy
@@ -32,6 +32,7 @@ void call(Map opts = [:]) {
     git config --global user.email jenkins@tietoevry.com
     git config --global user.name "Jenkins the autonomous"
 
+    rm -rf gitops
     git clone ${origin} gitops
     cd gitops
     git fetch -a


### PR DESCRIPTION
When a build agent uses the same workspace for multi stage the gitops folder is not empty
after first stage. I.e.  git clone ${origin} gitops fails due to not empty folder