### PR TITLE
Fix illegal string value in acePushConfigToGit

### DIFF
--- a/vars/acePushConfigToGit.groovy
+++ b/vars/acePushConfigToGit.groovy
@@ -4,7 +4,7 @@ void call(Map opts = [:]) {
 
   target = readYaml file: 'target-data/target.yaml'
   cfg = readYaml file: opts.aceFile ?: 'ace.yaml'
-  sh "gitOpsfolder=$(mktemp -d gitOpsXXXXXX)"
+  sh "gitOpsfolder=\$(mktemp -d gitOpsXXXXXX)"
   Map gitops = cfg.gitops ?: [:]
   String gitopsRepo = gitops.repo
   String strategy = gitops.strategy ?: 'path'


### PR DESCRIPTION
## Description

1. Adding a informative description

Bugfix - illegal char in shell command.

2. You need to decide if this is a #major, #minor or #patch update. Put one of these in the description:

#patch

error in build pipeline:

/var/jenkins_home/jobs/BKK-Digitek/jobs/bkk-deko-pain/branches/main/builds/1/libs/ace/vars/acePushConfigToGit.groovy: 7: illegal string body character after dollar sign;
   solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 7, column 3.
     sh "gitOpsfolder=$(mktemp -d gitOpsXXXXXX)"


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have made design choices.
- [ ] My design choices are documented in an Architecture Decision Record in the adr/ folder of this repo.

## Issues this PR fixes
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

